### PR TITLE
add libssh2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,29 @@
 FROM amazonlinux:latest
 
-ARG libgit2_version=0.28.1
-ARG pygit2_version=0.28.1
+ARG libgit2_version=1.1.0
+ARG pygit2_version=1.5.0
+ARG libssh2_version=1.9.0
+ARG libssh2_daily=20210330
+ARG cmake_version=3.20.0
 
-RUN yum install -y python3-pip python3-devel gcc cmake tar gzip make openssl-devel
+RUN yum install -y python3-pip python3-devel gcc cmake tar gzip make openssl-devel gcc-c++
+
+# Build cmake libgit2 wants 3+ and amazonlinux be ancient
+RUN curl -L --output cmake.tgz https://github.com/Kitware/CMake/releases/download/v${cmake_version}/cmake-${cmake_version}.tar.gz && \
+    tar xzvf cmake.tgz && \
+    cd cmake-${cmake_version} && \
+    ./bootstrap --parallel=4 && make && make install
+
+
+# Build libssh2 (1.9 amazonlinux ships 1.4) we want latest for ed25519 key support
+RUN curl -L --output libssh2.tgz https://www.libssh2.org/snapshots/libssh2-${libssh2_version}-${libssh2_daily}.tar.gz && \
+    tar xzvf libssh2.tgz && \
+    cd libssh2-${libssh2_version}-${libssh2_daily} && \
+    ./configure --prefix=/opt && \
+    make && \
+    make install
 
 # Build LibGit2
-
 RUN curl -L --output libgit2.tgz  https://github.com/libgit2/libgit2/archive/v${libgit2_version}.tar.gz && \
     tar xzvf libgit2.tgz  && \
     cd libgit2-${libgit2_version} && \


### PR DESCRIPTION
this isn't really needed anymore pygit2 packages up libgit2 with static libssh2 in manywheel style releases.